### PR TITLE
Adding repo to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,15 +1,16 @@
 {
   "name": "express-able",
   "version": "0.2.0",
-  "description": "",
+  "description": "Able A/B testing middleware for express",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "author": "",
+  "author": "Danny Coates <dannycoates@gmail.com>",
   "license": "MPL 2.0",
   "dependencies": {
     "able": "0.2.0",
     "parseurl": "1.3.0"
-  }
+  },
+  "repository": "dannycoates/express-able"
 }


### PR DESCRIPTION
This should fix the "npm WARN package.json express-able@0.2.0 No repository field." warning that we're seeing when installing fxa-content-server (plus make it easier to find the GitHub repo if you're browsing the module on npmjs.org)
